### PR TITLE
pre-install-payload: Handle the nydus-snapshotter

### DIFF
--- a/config/samples/ccruntime/base/ccruntime.yaml
+++ b/config/samples/ccruntime/base/ccruntime.yaml
@@ -55,6 +55,8 @@ spec:
           name: confidential-containers-artifacts
         - mountPath: /etc/systemd/system/
           name: etc-systemd-system
+        - mountPath: /etc/containerd/
+          name: containerd-conf
       volumes:
         - hostPath:
             path: /opt/confidential-containers/
@@ -64,6 +66,10 @@ spec:
             path: /etc/systemd/system/
             type: ""
           name: etc-systemd-system
+        - hostPath:
+            path: /etc/containerd/
+            type: ""
+          name: containerd-conf
       environmentVariables:
         # If set to true, this will install the CoCo fork of the containerd,
         # the one allowing images to be pulled inside the guest and has patches
@@ -80,6 +86,11 @@ spec:
         # default: false
         - name: "INSTALL_VFIO_GPU_CONTAINERD"
           value: "false"
+        # If set to true, this will install nydus-snapshotter and nydus-image
+        # on the node
+        # default: false
+        - name: "INSTALL_NYDUS_SNAPSHOTTER"
+          value: "false"
     preInstall:
       image: quay.io/confidential-containers/reqs-payload
       volumeMounts:
@@ -87,6 +98,8 @@ spec:
           name: confidential-containers-artifacts
         - mountPath: /etc/systemd/system/
           name: etc-systemd-system
+        - mountPath: /etc/containerd/
+          name: containerd-conf
       volumes:
         - hostPath:
             path: /opt/confidential-containers/
@@ -96,6 +109,10 @@ spec:
             path: /etc/systemd/system/
             type: ""
           name: etc-systemd-system
+        - hostPath:
+            path: /etc/containerd/
+            type: ""
+          name: containerd-conf
       environmentVariables:
         # If set to true, this will install the CoCo fork of the containerd,
         # the one allowing images to be pulled inside the guest and has patches
@@ -110,6 +127,11 @@ spec:
         # the one that has patches for handling GPU / VFIO, on the node
         # default: false
         - name: "INSTALL_VFIO_GPU_CONTAINERD"
+          value: "false"
+        # If set to true, this will install nydus-snapshotter and nydus-image
+        # on the node
+        # default: false
+        - name: "INSTALL_NYDUS_SNAPSHOTTER"
           value: "false"
     environmentVariables:
       - name: NODE_NAME

--- a/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
+++ b/config/samples/enclave-cc/base/ccruntime-enclave-cc.yaml
@@ -49,11 +49,17 @@ spec:
     postUninstall:
       image: quay.io/confidential-containers/reqs-payload
       volumeMounts:
+        - mountPath: /etc/containerd/
+          name: containerd-conf
         - mountPath: /opt/confidential-containers/
           name: confidential-containers-artifacts
         - mountPath: /etc/systemd/system/
           name: etc-systemd-system
       volumes:
+        - hostPath:
+            path: /etc/containerd/
+            type: ""
+          name: containerd-conf
         - hostPath:
             path: /opt/confidential-containers/
             type: DirectoryOrCreate
@@ -75,15 +81,26 @@ spec:
         # the one that has patches for handling GPU / VFIO, on the node
         # default: false
         - name: "INSTALL_VFIO_GPU_CONTAINERD"
+          value: "false"
+        # If set to true, this will install nydus-snapshotter and nydus-image
+        # on the node
+        # default: false
+        - name: "INSTALL_NYDUS_SNAPSHOTTER"
           value: "false"
     preInstall:
       image: quay.io/confidential-containers/reqs-payload
       volumeMounts:
+        - mountPath: /etc/containerd/
+          name: containerd-conf
         - mountPath: /opt/confidential-containers/
           name: confidential-containers-artifacts
         - mountPath: /etc/systemd/system/
           name: etc-systemd-system
       volumes:
+        - hostPath:
+            path: /etc/containerd/
+            type: ""
+          name: containerd-conf
         - hostPath:
             path: /opt/confidential-containers/
             type: DirectoryOrCreate
@@ -105,6 +122,11 @@ spec:
         # the one that has patches for handling GPU / VFIO, on the node
         # default: false
         - name: "INSTALL_VFIO_GPU_CONTAINERD"
+          value: "false"
+        # If set to true, this will install nydus-snapshotter and nydus-image
+        # on the node
+        # default: false
+        - name: "INSTALL_NYDUS_SNAPSHOTTER"
           value: "false"
     environmentVariables:
       - name: NODE_NAME

--- a/install/pre-install-payload/Dockerfile
+++ b/install/pre-install-payload/Dockerfile
@@ -54,6 +54,35 @@ RUN \
 	tar xvzpf containerd-${VFIO_GPU_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz -C ${NODE_DESTINATION} && \
 	rm containerd-${VFIO_GPU_CONTAINERD_VERSION}-linux-${ARCH}.tar.gz
 
+#### Nydus snapshotter & nydus image
+
+FROM golang:1.19-alpine AS nydus-binary-downloader
+
+ARG ARCH
+ARG NYDUS_SNAPSHOTTER_VERSION
+ARG NYDUS_SNAPSHOTTER_REPO
+ARG NYDUS_REPO
+ARG NYDUS_VERSION
+
+ARG DESTINATION=/opt/confidential-containers-pre-install-artifacts
+ARG NODE_DESTINATION=${DESTINATION}/opt/confidential-containers
+
+RUN mkdir -p ${NODE_DESTINATION}/bin && \
+    apk add --no-cache ca-certificates build-base git curl && \
+    git clone ${NYDUS_SNAPSHOTTER_REPO} -b ${NYDUS_SNAPSHOTTER_VERSION} /nydus-snapshotter && \
+    make -C /nydus-snapshotter && \
+    chmod +x /nydus-snapshotter/bin/containerd-nydus-grpc && \
+    mv /nydus-snapshotter/bin/containerd-nydus-grpc ${NODE_DESTINATION}/bin && \
+    rm -rf /nydus-snapshotter && \
+    # FIXME: THIS IS x86_64 SPECIFIC, AND SHOULD BE FIXED BEFORE GETTING MERGED, \
+    # AS IT BREAKS s390x BUILD \
+    curl -fOL --progress-bar ${NYDUS_REPO}/releases/download/${NYDUS_VERSION}/nydus-static-${NYDUS_VERSION}-linux-${ARCH}.tgz && \
+    tar xvzpf nydus-static-${NYDUS_VERSION}-linux-${ARCH}.tgz -C / && \
+    chmod +x /nydus-static/nydus-image && \
+    mv /nydus-static/nydus-image ${NODE_DESTINATION}/bin && \
+    rm -rf /nydus-static && \
+    rm -f nydus-static-${NYDUS_VERSION}-linux-${ARCH}.tgz && \
+    apk del build-base git curl
 
 #### kubectl
 
@@ -78,12 +107,18 @@ ARG NODE_DESTINATION=${DESTINATION}/opt/confidential-containers
 ARG NODE_CONTAINERD_SYSTEMD_DESTINATION=${DESTINATION}/etc/systemd/system/containerd.service.d/
 
 ARG CONTAINERD_SYSTEMD_ARTIFACTS=./containerd/containerd-for-cc-override.conf
+ARG NYDUS_SNAPSHOTTER_ARTIFACTS=./remote-snapshotter/nydus-snapshotter/config.toml
 
 COPY --from=coco-containerd-binary-downloader ${NODE_DESTINATION}/bin/containerd ${NODE_DESTINATION}/bin/coco-containerd
 COPY --from=official-containerd-binary-downloader ${NODE_DESTINATION}/bin/containerd ${NODE_DESTINATION}/bin/official-containerd
 COPY --from=vfio-gpu-containerd-binary-downloader ${NODE_DESTINATION}/bin/containerd ${NODE_DESTINATION}/bin/vfio-gpu-containerd
+COPY --from=nydus-binary-downloader ${NODE_DESTINATION}/bin/containerd-nydus-grpc ${NODE_DESTINATION}/bin/containerd-nydus-grpc
+COPY --from=nydus-binary-downloader ${NODE_DESTINATION}/bin/nydus-image ${NODE_DESTINATION}/bin/nydus-image
 COPY --from=kubectl-binary-downloader /usr/bin/kubectl /usr/bin/kubectl
 COPY ${CONTAINERD_SYSTEMD_ARTIFACTS} ${NODE_CONTAINERD_SYSTEMD_DESTINATION}
+COPY ${NYDUS_SNAPSHOTTER_ARTIFACTS} ${NODE_DESTINATION}/share/nydus-snapshotter
 
 ARG CONTAINER_ENGINE_ARTIFACTS=./scripts
 COPY ${CONTAINER_ENGINE_ARTIFACTS}/* ${DESTINATION}/scripts/
+
+

--- a/install/pre-install-payload/Makefile
+++ b/install/pre-install-payload/Makefile
@@ -1,6 +1,8 @@
 COCO_CONTAINERD_VERSION = 1.6.8.2
 OFFICIAL_CONTAINERD_VERSION = 1.7.0
 VFIO_GPU_CONTAINERD_VERSION = 1.7.0.0
+NYDUS_SNAPSHOTTER_VERSION = v0.10.0
+NYDUS_VERSION= v2.2.3
 
 BASH = bash
 
@@ -8,4 +10,6 @@ reqs-image:
 	coco_containerd_version=$(COCO_CONTAINERD_VERSION) \
 	official_containerd_version=$(OFFICIAL_CONTAINERD_VERSION) \
 	vfio_gpu_containerd_version=$(VFIO_GPU_CONTAINERD_VERSION) \
+	nydus_snapshotter_version=${NYDUS_SNAPSHOTTER_VERSION} \
+	nydus_version=${NYDUS_VERSION} \
 	$(BASH) -x payload.sh

--- a/install/pre-install-payload/payload.sh
+++ b/install/pre-install-payload/payload.sh
@@ -12,6 +12,10 @@ official_containerd_repo=${official_containerd_repo:-"https://github.com/contain
 official_containerd_version=${official_containerd_version:-"1.7.0"}
 vfio_gpu_containerd_repo=${vfio_gpu_containerd_repo:-"https://github.com/confidential-containers/containerd"}
 vfio_gpu_containerd_version=${vfio_gpu_containerd_version:-"1.7.0.0"}
+nydus_snapshotter_repo=${nydus_snapshotter_repo:-"https://github.com/containerd/nydus-snapshotter"}
+nydus_snapshotter_version=${nydus_snapshotter_version:-"v0.10.0"}
+nydus_repo=${nydus_repo:-"https://github.com/dragonflyoss/image-service"}
+nydus_version=${nydus_version:-"v2.2.3"}
 containerd_dir="$(mktemp -d -t containerd-XXXXXXXXXX)/containerd"
 extra_docker_manifest_flags="${extra_docker_manifest_flags:-}"
 
@@ -66,6 +70,10 @@ function build_payload() {
 			--build-arg OFFICIAL_CONTAINERD_REPO="${official_containerd_repo}" \
 			--build-arg VFIO_GPU_CONTAINERD_VERSION="${vfio_gpu_containerd_version}" \
 			--build-arg VFIO_GPU_CONTAINERD_REPO="${vfio_gpu_containerd_repo}" \
+			--build-arg NYDUS_SNAPSHOTTER_VERSION="${nydus_snapshotter_version}" \
+			--build-arg NYDUS_SNAPSHOTTER_REPO="${nydus_snapshotter_repo}" \
+			--build-arg NYDUS_VERSION="${nydus_version}" \
+			--build-arg NYDUS_REPO="${nydus_repo}" \
 			-t "${registry}:${kernel_arch}-${tag}" \
 			--platform="${arch}" \
 			--load \

--- a/install/pre-install-payload/remote-snapshotter/nydus-snapshotter/config.toml
+++ b/install/pre-install-payload/remote-snapshotter/nydus-snapshotter/config.toml
@@ -1,0 +1,48 @@
+version = 1
+# Snapshotter's own home directory where it stores and creates necessary resources
+root = "/var/lib/containerd-nydus"
+# The snapshotter's GRPC server socket, containerd will connect to plugin on this socket
+address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
+daemon_mode = "none"
+# Whether snapshotter should try to clean up resources when it is closed
+cleanup_on_close = false
+
+[daemon]
+nydusimage_path = "/opt/confidential-containers/bin/nydus-image"
+
+[log]
+# Print logs to stdout rather than logging files
+log_to_stdout = true
+# Snapshotter's log level
+level = "debug"
+
+[snapshot]
+# Let containerd use nydus-overlayfs mount helper
+enable_nydus_overlayfs = true
+# Whether to remove resources when a snapshot is removed
+sync_remove = false
+
+# The configuraions for features that are not production ready
+[experimental]
+# Whether to enable stargz support
+enable_stargz = false
+# Whether to enable referrers support
+# The option enables trying to fetch the Nydus image associated with the OCI image and run it.
+# Also see https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers
+enable_referrer_detect = false
+[experimental.tarfs]
+# Whether to enable nydus tarfs mode
+enable_tarfs = true
+# Only enable nydus tarfs mode for images with `tarfs hint` label when true
+tarfs_hint = false
+# Maximum of concurrence to converting OCIv1 images to tarfs, 0 means default
+max_concurrent_proc = 0
+# Mode to export tarfs images: 
+# - "none"/""
+# - "layer_verity_only"
+# - "image_verity_only"
+# - "layer_block"
+# - "image_block"
+# - "layer_block_with_verity"
+# - "image_block_with_verity"
+export_mode = ""

--- a/install/pre-install-payload/scripts/reqs-deploy.sh
+++ b/install/pre-install-payload/scripts/reqs-deploy.sh
@@ -4,6 +4,8 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
+containerd_config="/etc/containerd/config.toml"
+
 die() {
 	msg="$*"
 	echo "ERROR: $msg" >&2
@@ -20,7 +22,7 @@ function get_container_engine() {
 		die "${container_engine} is not yet supported"
 	fi
 
-	echo "$container_engine"	
+	echo "$container_engine"
 }
 
 function set_container_engine() {
@@ -38,7 +40,6 @@ function install_containerd_artefacts() {
 
 	install -D -m 755 ${artifacts_dir}/opt/confidential-containers/bin/${flavour}-containerd /opt/confidential-containers/bin/containerd
 	install -D -m 644 ${artifacts_dir}/etc/systemd/system/containerd.service.d/containerd-for-cc-override.conf /etc/systemd/system/containerd.service.d/containerd-for-cc-override.conf
-
 }
 
 function install_coco_containerd_artefacts() {
@@ -53,6 +54,17 @@ function install_vfio_gpu_containerd_artefacts() {
 	install_containerd_artefacts "vfio-gpu"
 }
 
+function install_nydus_snapshotter_artefacts() {
+	echo "Copying nydus-snapshotter artifacts onto host"
+	install -D -m 755 ${artifacts_dir}/opt/confidential-containers/bin/containerd-nydus-grpc /opt/confidential-containers/bin/containerd-nydus-grpc
+	install -D -m 755 ${artifacts_dir}/opt/confidential-containers/bin/nydus-image /opt/confidential-containers/bin/nydus-image
+	install -D -m 644 ${artifacts_dir}/opt/confidential-containers/share/nydus-snapshotter/config.toml /opt/confidential-containers/share/nydus-snapshotter/config.toml
+
+	configure_nydus_snapshotter_for_containerd
+
+	restart_systemd_service
+}
+
 function install_artifacts() {
 	if [ "${INSTALL_COCO_CONTAINERD}" = "true" ]; then
 		install_coco_containerd_artefacts
@@ -65,6 +77,10 @@ function install_artifacts() {
 	if [ "${INSTALL_VFIO_GPU_CONTAINERD}" = "true" ]; then
 		install_vfio_gpu_containerd_artefacts
 	fi
+
+	if [ "${INSTALL_NYDUS_SNAPSHOTTER}" = "true" ]; then
+		install_nydus_snapshotter_artefacts
+	fi
 }
 
 function uninstall_containerd_artefacts() {
@@ -76,7 +92,7 @@ function uninstall_containerd_artefacts() {
 	if [ -d /etc/systemd/system/${container_engine}.service.d ]; then
 		rmdir --ignore-fail-on-non-empty /etc/systemd/system/${container_engine}.service.d
 	fi
-	
+
 	restart_systemd_service
 
 	echo "Removing the containerd binary"
@@ -85,6 +101,17 @@ function uninstall_containerd_artefacts() {
 	if [ -d /opt/confidential-containers/bin ]; then
 		rmdir --ignore-fail-on-non-empty -p /opt/confidential-containers/bin
 	fi
+}
+
+functional uninstall_nydus_snapshotter_artefacts() {
+	remove_nydus_snapshotter_from_containerd
+
+	restart_systemd_service
+
+	echo "Removing nydus-snapshotter artifacts from host"
+	rm -f /opt/confidential-containers/bin/containerd-nydus-grpc
+	rm -f /opt/confidential-containers/bin/nydus-image
+	rm -f /opt/confidential-containers/share/remote-snapshotter/config.toml
 }
 
 function uninstall_artifacts() {
@@ -97,6 +124,33 @@ function restart_systemd_service() {
 	host_systemctl daemon-reload
 	echo "Restarting ${container_engine}"
 	host_systemctl restart "${container_engine}"
+}
+
+function configure_nydus_snapshotter_for_containerd() {
+	echo "configure nydus snapshotter for containerd"
+
+	if [ ! -f "$containerd_config" ]; then
+		die "failed to find containerd config"
+	fi
+
+	if [ "${INSTALL_NYDUS_SNAPSHOTTER}" = "true" ]; then
+		echo "Plug nydus snapshotter into containerd"
+		snapshotter_socket="/run/containerd-nydus/containerd-nydus-grpc.sock"
+	fi
+	proxy_config="  [proxy_plugins.$SNAPSHOTTER]\n    type = \"snapshot\"\n    address = ${snapshotter_socket}"
+
+	if grep -q "\[proxy_plugins\]" "$containerd_config"; then
+		sed -i '/\[proxy_plugins\]/a\'"$proxy_config" "$containerd_config"
+	else
+		echo -e "[proxy_plugins]" >>"$containerd_config"
+		echo -e "$proxy_config" >>"$containerd_config"
+	fi
+}
+
+function remove_nydus_snapshotter_from_containerd() {
+	echo "Remove nydus snapshotter from containerd"
+
+	sed -i '/\[proxy_plugins.nydus\]/,/address = "\/run\/containerd-nydus\/containerd-nydus-grpc\.sock"/d' "$containerd_config"
 }
 
 label_node() {
@@ -120,6 +174,7 @@ function main() {
 	echo "INSTALL_COCO_CONTAINERD: ${INSTALL_COCO_CONTAINERD}"
 	echo "INSTALL_OFFICIAL_CONTAINERD: ${INSTALL_OFFICIAL_CONTAINERD}"
 	echo "INSTALL_VFIO_GPU_CONTAINERD: ${INSTALL_VFIO_GPU_CONTAINERD}"
+	echo "INSTALL_NYDUS_SNAPSHOTTER: ${INSTALL_NYDUS_SNAPSHOTTER}"
 
 	# script requires that user is root
 	local euid=$(id -u)


### PR DESCRIPTION
nydus-snapshotter / nydus will be used to get rid of the containerd fork we have, allowing us to do both the image pulling on the host side and inside the guest.

NOTE:
This PR should NOT be merged as it's, as it breaks s390x payload build.